### PR TITLE
Fixed compilation problem on case sensitive filesystems, e.g. Linux. …

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -18,7 +18,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
-#include <Plugin.h>
+#include <plugin.h>
 
 Plugin::Plugin() {
 	packet = 0;


### PR DESCRIPTION
…Header file cannot be found becasue of uppercase 'P' in #include "Plugin.h".