### PR TITLE
Create library.json for platformio

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,18 @@
+{
+  "name": "homeGW",
+  "keywords": "sensor, temperature",
+  "description": "DG-R8H decoding library",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/dgomes/homeGW.git"
+  },
+  "authors":
+  [
+    {
+      "name": "Diogo Gomes",
+      "url": "http://www.diogogomes.com"
+    }
+  ],
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Hi,

I intend to use your lib into a esphome device. To ease the inclusion of your dgomes/homeGW library I wanted to use platformio like all my other dependencies to date. 

I have read the documentation at https://docs.platformio.org/en/latest/librarymanager/creating.html and created a manifest file.  

Would you be interested by this merge request ? A tag will be required to match the "version".

My testing might also already started the process of accreditation...
```
$ platformio lib register https://raw.githubusercontent.com/PascalNoisette/homeGW/master/library.json
The library has been successfully registered and is waiting for moderation
```


Regards,
Pascal Noisette